### PR TITLE
Use OpenLibrary Book API instead of ebooks.de

### DIFF
--- a/README.org
+++ b/README.org
@@ -15,8 +15,8 @@ library knows about the following formats:
 Given an identifier in one of the known formats, the libray can query
 information about the resources and format it as a bibtex entry. To do
 so, the library primarily use the crossref.org API (doi,pmid, pcmi),
-openalex.org API (issn), arxiv API (arxiv) and ebook.de (isbn)
-Unfortunately, ebook.de is far from being complete and a lot of ISBN
+openalex.org API (issn), arxiv API (arxiv) and OpenLibrary (isbn)
+Unfortunately, OpenLibrary is far from being complete and a lot of ISBN
 records are missing.
 
 The main function is the interactive =persid-bibtex-from= function
@@ -33,7 +33,7 @@ is queried online:
 - *arxiv*: [[https://arxiv.org/help/api/][arXiv API]] is used to get bibtex
 - *issn*: [[https://docs.openalex.org/][OpenAlex API]] is used to get the name and the
   publisher information. 
-- *isbn*: not yet implemented (lack of consistent open database)
+- *isbn*: [[https://openlibrary.org/dev/docs/api/books][OpenLibrary Book API]] is used to get bibtex
 
 *See also*: [[https://guides.lib.berkeley.edu/information-studies/apis][Information Studies: APIs for scholarly resources]]
 

--- a/README.org
+++ b/README.org
@@ -98,3 +98,6 @@ archivePrefix = {arXiv},
   server and insert a formatted BibTeX entry in the current buffer.
 
 - [[https://github.com/emacs-citar/citar][Citar]] provides a highly-configurable completing-read front-end to browse and act on BibTeX, BibLaTeX, and CSL JSON bibliographic data, and LaTeX, markdown, and org-cite editing support.
+
+- [[https://www.github.com/fabcontigiani/biblio-openlibrary][biblio-openlibrary]] provides an OpenLibrary backend for ~biblio.el~, allowing to
+  /interactively/ browse and gather bibliographic entries from OpenLibrary by ISBN.

--- a/persid.el
+++ b/persid.el
@@ -112,9 +112,9 @@ set by the user.
 The creation of the citekey is handled by the built-in `bibtex-mode' via the
 `bibtex-clean-entry' callable, and should respect user's configuration of the
 package, see `bibtex-generate-autokey'."
-  :type '(choice (const :tag "Generate citekey automatically" t)
-                 (const :tag "Prompt user after generating citekey" 'prompt)
-                 (const :tag "Respect user's configuration" 'user)
+  :type '(choice (symbol :tag "Generate citekey automatically" t)
+                 (symbol :tag "Prompt user after generating citekey" 'prompt)
+                 (symbol :tag "Respect user's configuration" 'user)
                  (const :tag "Don't generate citekey" nil)))
 
 (defconst persid-formats '(isbn issn doi pmid pmcid arxiv)

--- a/persid.el
+++ b/persid.el
@@ -4,7 +4,7 @@
 
 ;; Maintainer: Nicolas P. Rougier <Nicolas.Rougier@inria.fr>
 ;; URL: https://github.com/rougier/emacs-persid
-;; Version: 0.1.0
+;; Version: 0.1.1
 ;; Package-Requires: ((emacs "27.1"))
 ;; Keywords: text, bib, references 
 

--- a/persid.el
+++ b/persid.el
@@ -441,9 +441,8 @@ url       = {%s},
         (when persid-isbn-generate-citekey
           (bibtex-mode)
           (unless (eq persid-isbn-generate-citekey 'user)
-            (if (eq persid-isbn-generate-citekey 'prompt)
-                (setq-local bibtex-autokey-edit-before-use t)
-              (setq-local bibtex-autokey-edit-before-use nil)))
+            (setq-local bibtex-autokey-edit-before-use
+                        (eq persid-isbn-generate-citekey 'prompt)))
           (bibtex-clean-entry t))
         (buffer-string)))))
 

--- a/persid.el
+++ b/persid.el
@@ -231,8 +231,8 @@ See https://arxiv.org/help/arxiv_identifier_for_services")
 ;; http://classify.oclc.org/classify2/Classify?isbn=%s&summary=true
 ;; https://www.googleapis.com/books/v1/volumes?q=%s+isbn&maxResults=1
 (defconst persid-isbn-query-url
-  "https://www.ebook.de/de/tools/isbn2bibtex?isbn=%s"
-  "URL to query for an isbn book (bibtex).")
+  "http://openlibrary.org/api/books?bibkeys=ISBN:%s&format=json&jscmd=data"
+  "URL to query for an isbn book (json).")
 
 
 (defconst persid-issn-query-url

--- a/persid.el
+++ b/persid.el
@@ -43,9 +43,8 @@
 ;; query information about the resources and format it as a bibtex
 ;; entry. To do so, the library primarily use the crossref.org API
 ;; (doi,pmid, pcmi), openalex.org API (issn), arxiv API (arxiv)
-;; and ebook.de (isbn) Unfortunately, ebook.de is far
-;; from being complete and a lot of ISBN records are
-;; missing.
+;; and OpenLibrary Book API (isbn). Unfortunately, OpenLibrary is
+;; far from being complete and a lot of ISBN records are missing.
 ;;
 ;; The main function is the interactive `persid-bibtex-from` function
 ;; that accept a single identifier and return the corresponding
@@ -60,7 +59,7 @@
 ;;           and then the crossref is used.
 ;; - arxiv: the arxiv API is used
 ;; - issn (info only): the openalex API is used
-;; - isbn: ebook.de
+;; - isbn: the OpenLibrary Book API is used
 ;;
 ;; See also:
 ;;   Information Studies: APIs for scholarly resources

--- a/persid.el
+++ b/persid.el
@@ -409,10 +409,18 @@ See more: https://openlibrary.org/dev/docs/api/books"
   "Retrieve bibtex information from an ISBN IDENTIFIER"
 
   (when-let ((isbn (persid-isbn-check identifier)))
-    (let* ((url (format persid-isbn-query-url isbn)))
-      (with-temp-buffer
-        (url-insert-file-contents url)
-        (buffer-string)))))
+    (let* ((url (format persid-isbn-query-url isbn))
+           (info (persid--info-from-openlibrary url))
+           (bibtex (let-alist info
+                     (format "@book{,
+title     = {%s},
+author    = {%s},
+publisher = {%s},
+year      = {%s},
+isbn      = {%s},
+url       = {%s},
+}" .title .author .publisher .year .isbn .url))))
+      bibtex)))
 
 (defun persid--decode-entities (html)
   "Decode HTML entities.

--- a/persid.el
+++ b/persid.el
@@ -411,7 +411,7 @@ See more: https://openlibrary.org/dev/docs/api/books"
     (let* ((url (format persid-isbn-query-url isbn))
            (info (persid--info-from-openlibrary url))
            (bibtex (let-alist info
-                     (format "@book{,
+                     (format "@book{NO_KEY,
 title     = {%s},
 author    = {%s},
 publisher = {%s},

--- a/persid.el
+++ b/persid.el
@@ -410,13 +410,13 @@ See more: https://openlibrary.org/dev/docs/api/books"
     (url-insert-file-contents openlibrary-url)
     (let-alist (cdar (json-read))
       (list (cons 'title .title)
-            (cons 'author (s-join " and " (mapcar #'cdadr .authors)))
+            (cons 'author (string-join (mapcar #'cdadr .authors) " and "))
             (cons 'year (format-time-string
                          "%Y"
                          (encode-time
                           (decoded-time-set-defaults
                            (parse-time-string .publish_date)))))
-            (cons 'publisher (s-join " and " (mapcar #'cdar .publishers)))
+            (cons 'publisher (string-join (mapcar #'cdar .publishers) " and "))
             (cons 'isbn (car (append (or .identifiers.isbn_13
                                          .identifiers.isbn_10) nil)))
             (cons 'url .url)))))


### PR DESCRIPTION
Hi Nicolas! First, I wanted to thank you for creating this package and for your contributions to the Emacs community in general! Big fan of your work ^^

OpenLibrary was suggested on #4 as an alternative source for retrieving bibliographic entries based on ISBN. Recently I dabbled with one of OpenLibrary's APIs ([biblio-openlibrary](https://www.github.com/fabcontigiani/biblio-openlibrary)), and wanted to contribute to this package too, since it may fit better in the workflow I wanna implement with the built-in bibtex-mode and citar.

This PR uses the Book API from OpenLibrary to receive a response in JSON form given a valid ISBN identifier, then parses it extracting the necessary information to create a BibTeX entry of type 'Book' from scratch, due to this previously being done on the server side by `ebooks.de`.

I decided to use OpenLibrary's "Legacy" Book API, as indicated on their documentation, seeing that it was possible to receive all needed information in a single query, in contrast, when using other APIs, e.g. the Search API, it was needed to perform an additional query for every author, since only their IDs is received. In addition, OpenLibrary's documentation only mentions the *posibility* of the Book API being phased out in the future, rather than it being a certainty. 

When compiling the package with the proposed changes I get an error, I'm still a noob when it comes to elisp and I'm not sure if and how I've introduced it:
```
Error (bytecomp): ‘add-to-list’ can’t use lexical var ‘formats’; use ‘push’ or ‘cl-pushnew’
```
Executing `package-install-file` on `persid.el` gives some more information:
```
Compiling file /home/fab/.config/emacs/elpa/persid-0.1.0/persid.el at Mon Mar 25 19:57:00 2024
Entering directory ‘/home/fab/.config/emacs/elpa/persid-0.1.0/’
persid.el:98:12: Warning: defcustom for ‘persid-mail-address’ fails to specify
    type
persid.el:98:12: Warning: defcustom for ‘persid-mail-address’ fails to specify
    containing group

In persid-identify:
persid.el:345:47: Error: ‘add-to-list’ can’t use lexical var ‘formats’; use
    ‘push’ or ‘cl-pushnew’
```
If it helps this is how I've installed and configured it in my init file:
```
(use-package persid
  :vc (:fetcher github :repo fabcontigiani/persid))
```
~Doing `M-x persid-bibtex-from` and providing a valid ISBN identifier doesn't work, nor does it throw an error for me at the moment, it does nothing really.~ Nevertheless, when evaluating `(insert (persid-bibtex-from-isbn "some-valid-isbn"))` the BibTeX entry gets inserted correctly, for example:
``` elisp
(insert (persid-bibtex-from-isbn "9781491952962")) ;; C-x C-e
```
I get: *(might need to add a new line jump or something, not sure)*
``` elisp
(insert (persid-bibtex-from-isbn "9781491952962"))@book{,
title     = {Practical Statistics for Data Scientists},
author    = {Peter Bruce and Andrew Bruce and Peter Gedeck},
publisher = {O’Reilly Media},
year      = {2017},
isbn      = {9781491952962},
url       = {http://openlibrary.org/books/OL26836530M/Practical_Statistics_for_Data_Scientists},
}
```
Notice the absence of a citekey, the creation of the BibTeX entry was done on the server side by ebooks.de previously, thus a citekey was generated there. As it stands now the generated BibTeX lacks this feature, but it allows the built-in `bibtex-mode` to autogenerate one for the user with the available information on the entries by pressing `C-c C-c`, if the bibtex major mode is active that is, this has the upside of respecting the user's configuration of the bibtex package making the generation of the citekey customizable, otherwise is up to the user to write one. It may be possible to automatically generate a key using the different tools made available with `bibtex.el` but it would add a dependency and complexity, which I'm not sure if it's desirable.

Also, I've added [biblio-openlibrary](https://www.github.com/fabcontigiani/biblio-openlibrary) to the related works mentioned on the readme, let me know if you feel it doesn't belong there and I'll remove it, no worries.

As I said, I'm still quite new to elisp and all feedback is well received. Cheers!




