### PR TITLE
Make main command more intuitive

### DIFF
--- a/README.org
+++ b/README.org
@@ -19,10 +19,10 @@ openalex.org API (issn), arxiv API (arxiv) and ebook.de (isbn)
 Unfortunately, ebook.de is far from being complete and a lot of ISBN
 records are missing.
 
-The main function is the interactive =persid-bibtex-from= function
+The main function is the interactive =persid-insert-bibtex= function
 that accept a single identifier and return the corresponding
-bibtex. To do that, the format of the identifier is first
-identified and normalized (if needed), then  the correspoding bibtex
+bibtex inserting it into the buffer. To do that, the format of the identifier is
+first identified and normalized (if needed), then the correspoding bibtex
 is queried online:
 
 - *doi*: [[https://www.crossref.org/documentation/retrieve-metadata/rest-api/a-non-technical-introduction-to-our-api/][Crossref API]] is used to get bibtex
@@ -40,7 +40,7 @@ is queried online:
 ** Example usage
 
 #+begin_src emacs-lisp
-(insert (persid-bibtex-from "arxiv:2008.06030"))
+(persid-insert-bibtex "arxiv:2008.06030")
 #+end_src
 
 #+begin_src bibtex

--- a/persid.el
+++ b/persid.el
@@ -431,10 +431,6 @@ normalized identifier."
     bibtex))
 
 ;;;###autoload
-(defun bibtex-from (identifier)
-  "Alias to `persid-bibtex-from `function"
-  
-  (persid-bibtex-from identifier))
 
 
 (defun persid--openalex/normalize-name (name)

--- a/persid.el
+++ b/persid.el
@@ -413,13 +413,9 @@ normalized identifier."
          (concat "@Article"
                  (buffer-substring beg (- end (length "</textarea>")))))))))
 
-;;;###autoload
 (defun persid-bibtex-from (identifier)
   "Retrieve bibtex information from given IDENTIFIER"
 
-  (interactive
-   (list (read-from-minibuffer "Identifier: " nil nil nil 'persid-history)))
-  
   (let ((formats (persid-identify identifier))
         (bitex))
     (catch 'found
@@ -431,7 +427,12 @@ normalized identifier."
     bibtex))
 
 ;;;###autoload
+(defun persid-insert-bibtex (identifier)
+  "Insert bibtex information from given IDENTIFIER."
 
+  (interactive
+   (list (read-from-minibuffer "Identifier: " nil nil nil 'persid-history)))
+  (insert (persid-bibtex-from identifier)))
 
 (defun persid--openalex/normalize-name (name)
   "Normalize NAME given as 'firstname(s) surname' to


### PR DESCRIPTION
This PR addresses the confusion raised on #5, which I also experienced, making the usage of the main command of persid more intuitive. The old behavior is still present under the same function (`persid-bibtex-from`), just removed the interactivity from that function since essentially it was intended to be called from elisp rather than `M-x`, kind of defeating the purpose of an interactive function in my opinion. 

Also deleted an alias which I think is way too generic, it could easily be confused with functions provided by other packages that handle BibTeX bibliographies, and now the main function, `persid-insert-bibtex`, I feel has a name easy enough to remember.