### PR TITLE
Replace OpenLibrary API with Google Books API for ISBN queries

### DIFF
--- a/README.org
+++ b/README.org
@@ -12,18 +12,16 @@ library knows about the following formats:
 - *pmcid*: PubMed Central (https://www.ncbi.nlm.nih.gov/pmc)
 - *arxiv*: Cornell University (https://arxiv.org)
 
-Given an identifier in one of the known formats, the libray can query
+Given an identifier in one of the known formats, the library can query
 information about the resources and format it as a bibtex entry. To do
 so, the library primarily use the crossref.org API (doi,pmid, pcmi),
-openalex.org API (issn), arxiv API (arxiv) and OpenLibrary (isbn)
-Unfortunately, OpenLibrary is far from being complete and a lot of ISBN
-records are missing.
+openalex.org API (issn), arxiv API (arxiv) and Google Books API (isbn).
 
 The main function is the interactive =persid-insert-bibtex= function
-that accept a single identifier and return the corresponding
-bibtex inserting it into the buffer. To do that, the format of the identifier is
-first identified and normalized (if needed), then the correspoding bibtex
-is queried online:
+that accepts a single identifier and returns the corresponding
+bibtex, inserting it into the buffer. To do that, the format of the
+identifier is first identified and normalized (if needed), then the
+corresponding bibtex is queried online:
 
 - *doi*: [[https://www.crossref.org/documentation/retrieve-metadata/rest-api/a-non-technical-introduction-to-our-api/][Crossref API]] is used to get bibtex
 - *pmid*: [[https://www.ncbi.nlm.nih.gov/pmc/tools/id-converter-api/][PubMed converter API]] is used to convert pmid to doi,
@@ -33,7 +31,7 @@ is queried online:
 - *arxiv*: [[https://arxiv.org/help/api/][arXiv API]] is used to get bibtex
 - *issn*: [[https://docs.openalex.org/][OpenAlex API]] is used to get the name and the
   publisher information. 
-- *isbn*: [[https://openlibrary.org/dev/docs/api/books][OpenLibrary Book API]] is used to get bibtex
+- *isbn*: [[https://developers.google.com/books/docs/overview][Google Books API]] is used to get bibtex
 
 *See also*: [[https://guides.lib.berkeley.edu/information-studies/apis][Information Studies: APIs for scholarly resources]]
 
@@ -101,3 +99,6 @@ archivePrefix = {arXiv},
 
 - [[https://www.github.com/fabcontigiani/biblio-openlibrary][biblio-openlibrary]] provides an OpenLibrary backend for ~biblio.el~, allowing to
   /interactively/ browse and gather bibliographic entries from OpenLibrary by ISBN.
+
+- [[https://github.com/jrasband/biblio-gbooks][biblio-gbooks]] provides a Google Books backend for biblio.el which can pull
+  BibTeX references directly from Google Books.

--- a/persid.el
+++ b/persid.el
@@ -100,23 +100,6 @@
 provide a faster access. Set it to nil if you prefer anonymous
 access.")
 
-(defcustom persid-isbn-generate-citekey nil
-  "If non-nil, automatically generate a citekey when getting BibTeX from ISBN.
-
-The value `prompt' means that the citekey will be presented to the user in the
-minibuffer area when generated, allowing for edits.
-
-The value `user' means to respect the value of `bibtex-autokey-edit-before-use'
-set by the user.
-
-The creation of the citekey is handled by the built-in `bibtex-mode' via the
-`bibtex-clean-entry' callable, and should respect user's configuration of the
-package, see `bibtex-generate-autokey'."
-  :type '(choice (symbol :tag "Generate citekey automatically" t)
-                 (symbol :tag "Prompt user after generating citekey" 'prompt)
-                 (symbol :tag "Respect user's configuration" 'user)
-                 (const :tag "Don't generate citekey" nil)))
-
 (defconst persid-formats '(isbn issn doi pmid pmcid arxiv)
   "List of known identifier formats")
 

--- a/persid.el
+++ b/persid.el
@@ -43,8 +43,7 @@
 ;; query information about the resources and format it as a bibtex
 ;; entry. To do so, the library primarily use the crossref.org API
 ;; (doi,pmid, pcmi), openalex.org API (issn), arxiv API (arxiv)
-;; and OpenLibrary Book API (isbn). Unfortunately, OpenLibrary is
-;; far from being complete and a lot of ISBN records are missing.
+;; and Google Books API (isbn).
 ;;
 ;; The main function is the interactive `persid-bibtex-from` function
 ;; that accept a single identifier and return the corresponding
@@ -59,7 +58,7 @@
 ;;           and then the crossref is used.
 ;; - arxiv: the arxiv API is used
 ;; - issn (info only): the openalex API is used
-;; - isbn: the OpenLibrary Book API is used
+;; - isbn: the Google Books API is used
 ;;
 ;; See also:
 ;;   Information Studies: APIs for scholarly resources
@@ -71,7 +70,7 @@
 ;; Example usage:
 ;; ==============
 ;; 
-;; (insert (persid-bibtex-from "arxiv:2008.06030"))
+;; (persid-insert-bibtex "arxiv:2008.06030")
 ;;
 ;; @Article{2020arXiv200806030R,
 ;;        author = {{Rougier}, Nicolas P.},

--- a/persid.el
+++ b/persid.el
@@ -4,7 +4,7 @@
 
 ;; Maintainer: Nicolas P. Rougier <Nicolas.Rougier@inria.fr>
 ;; URL: https://github.com/rougier/emacs-persid
-;; Version: 0.1.1
+;; Version: 0.1.2
 ;; Package-Requires: ((emacs "27.1"))
 ;; Keywords: text, bib, references 
 

--- a/persid.el
+++ b/persid.el
@@ -245,11 +245,14 @@ See https://arxiv.org/help/arxiv_identifier_for_services")
 ;; http://openlibrary.org/api/books?bibkeys=ISBN:%s&format=json&jscmd=data
 ;; http://www.librarything.com/services/rest/1.1/?method=librarything.ck.getwork&isbn=%s
 ;; http://classify.oclc.org/classify2/Classify?isbn=%s&summary=true
-;; https://www.googleapis.com/books/v1/volumes?q=%s+isbn&maxResults=1
+;; https://www.googleapis.com/books/v1/volumes?q=isbn:%s&maxResults=1
 (defconst persid-isbn-query-url
-  "http://openlibrary.org/api/books?bibkeys=ISBN:%s&format=json&jscmd=data"
+  "https://www.googleapis.com/books/v1/volumes?q=isbn:%s&maxResults=1"
   "URL to query for an isbn book (json).")
 
+(defconst persid-gbooks-id-query-url
+  "https://books.google.com/books?id=%s&output=bibtex"
+  "URL to query for a book using Google Books ID (bibtex).")
 
 (defconst persid-issn-query-url
   "https://api.openalex.org/venues/issn:%s"


### PR DESCRIPTION
Hi Nicolas!

OpenLibrary has been down for a few days now with the Internet Archive attack, so I took the opportunity to change the ISBN query to use [Google Books API](https://developers.google.com/books/docs/overview). Also updated the docs, fixed a couple of typos and added a mention of [biblio-gbooks](https://github.com/jrasband/biblio-gbooks) that inspired the changes.

It might be a good idea to close #4 and close #5 since those issues have been addressed already with this and my previous PRs (#6, #7).

Cheers!